### PR TITLE
feat: 언어 쿠키 처리 기능 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-echo "🔍 Lint, Format, Type Check, Test 실행 중..."
-
 pnpm lint-staged

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import { shared, page } from '@/constants/metadata';
+import { getLangFromCookie } from '@/lib/get-lang-from-cookie';
 
 import Main from './_components/main';
 
@@ -23,6 +24,11 @@ export const metadata: Metadata = {
   },
 };
 
-const MainPage = () => <Main />;
+const MainPage = async () => {
+  const lang = await getLangFromCookie();
+  console.log('NEXT_LANG 쿠키 값:', lang);
+
+  return <Main />;
+};
 
 export default MainPage;

--- a/src/components/shared/language-toggle.tsx
+++ b/src/components/shared/language-toggle.tsx
@@ -26,6 +26,7 @@ const LanguageToggle = () => {
     const newLang = i18n.language === 'ko' ? 'en' : 'ko';
     i18n.changeLanguage(newLang);
     setLang(newLang);
+    document.cookie = `NEXT_LANG=${newLang}; path=/;`;
   };
 
   return (

--- a/src/lib/__tests__/get-lang-from-cookie.test.ts
+++ b/src/lib/__tests__/get-lang-from-cookie.test.ts
@@ -1,0 +1,36 @@
+import { headers } from 'next/headers';
+
+import { getLangFromCookie } from '../get-lang-from-cookie';
+
+jest.mock('next/headers', () => ({
+  headers: jest.fn(),
+}));
+
+describe('getLangFromCookie', () => {
+  it('쿠키가 없을 경우 기본 언어 "ko"를 반환해야 합니다', async () => {
+    (headers as jest.Mock).mockReturnValue({
+      get: jest.fn().mockReturnValue(null),
+    });
+
+    const lang = await getLangFromCookie();
+    expect(lang).toBe('ko');
+  });
+
+  it('NEXT_LANG 쿠키에서 언어를 반환해야 합니다', async () => {
+    (headers as jest.Mock).mockReturnValue({
+      get: jest.fn().mockReturnValue('NEXT_LANG=en;'),
+    });
+
+    const lang = await getLangFromCookie();
+    expect(lang).toBe('en');
+  });
+
+  it('NEXT_LANG 쿠키가 설정되지 않은 경우 기본 언어 "ko"를 반환해야 합니다', async () => {
+    (headers as jest.Mock).mockReturnValue({
+      get: jest.fn().mockReturnValue('OTHER_COOKIE=value;'),
+    });
+
+    const lang = await getLangFromCookie();
+    expect(lang).toBe('ko');
+  });
+});

--- a/src/lib/get-lang-from-cookie.ts
+++ b/src/lib/get-lang-from-cookie.ts
@@ -1,0 +1,17 @@
+import { headers } from 'next/headers';
+
+export const getLangFromCookie = async () => {
+  const headersList = await headers();
+  const cookieHeader = headersList.get('cookie');
+
+  let lang = 'ko';
+
+  if (cookieHeader) {
+    const match = cookieHeader.match(/NEXT_LANG=([^;]*)/);
+    if (match) {
+      lang = match[1];
+    }
+  }
+
+  return lang;
+};


### PR DESCRIPTION
## 🔍 Overview

<!-- Briefly describe what this PR does -->
- 언어를 쿠키에 저장하는 기능 추가 (기본 언어는 'ko'로 설정)
- 추후에 서버 사이드에서 API 호출 할 때 lang 값을 보내주기 위함.

## ✅ What’s Included

<!-- Please check the relevant items below -->

- [x] Feature
- [ ] Bug Fix
- [ ] UI Enhancement
- [ ] Performance Improvement
- [ ] Code Refactor
- [ ] Test Code
- [ ] Others (describe below)

## 📸 Screenshots

<!-- Add screenshots if the PR includes UI work -->

## 🔗 Related Issues

<!-- Add related issue numbers if applicable -->

- Closes #

## 💬 Additional Notes

<!-- Any extra context, TODOs, or implementation details -->
