### PR TITLE
feat: 메인 페이지 스켈레톤 UI 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,7 +79,7 @@
     "import/newline-after-import": "warn",
 
     "@typescript-eslint/no-unused-vars": [
-      "warn",
+      "error",
       { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
     ],
 

--- a/src/app/(main)/_components/code-view.tsx
+++ b/src/app/(main)/_components/code-view.tsx
@@ -5,112 +5,133 @@ import { cn } from '@/lib/utils';
 import type { HelloResponse } from '@/types/hello';
 import type { Language } from '@/types/language';
 
+type SkeletonSize = {
+  height: string;
+  smWidth: string;
+};
+
+type SkeletonSizeMap = {
+  title: SkeletonSize;
+  github: SkeletonSize;
+  email: SkeletonSize;
+  text01: SkeletonSize;
+  text02: SkeletonSize;
+};
+
+const SKELETON_SIZES: Record<Language, SkeletonSizeMap> = {
+  ko: {
+    title: { height: '34px', smWidth: '435px' },
+    github: { height: '24px', smWidth: '397px' },
+    email: { height: '24px', smWidth: '378px' },
+    text01: { height: '20px', smWidth: '397px' },
+    text02: { height: '20px', smWidth: '220px' },
+  },
+  en: {
+    title: { height: '34px', smWidth: '460px' },
+    github: { height: '24px', smWidth: '590px' },
+    email: { height: '24px', smWidth: '590px' },
+    text01: { height: '20px', smWidth: '530px' },
+    text02: { height: '20px', smWidth: '370px' },
+  },
+};
+
 type Props = {
   data: HelloResponse;
   isFetching: boolean;
   language: Language;
 };
 
-type SkeletonSize = {
-  title: string;
-  github: string;
-  email: string;
-  text01: string;
-  text02: string;
-};
+const CodeView = ({ data, isFetching, language }: Props) => {
+  const skeleton = SKELETON_SIZES[language];
 
-const SKELETON_WIDTH: Record<Language, SkeletonSize> = {
-  ko: {
-    title: '460.8px',
-    github: '589.61px',
-    email: '589.61px',
-    text01: '529.2px',
-    text02: '369.61px',
-  },
-  en: {
-    title: '460.8px',
-    github: '589.61px',
-    email: '589.61px',
-    text01: '529.2px',
-    text02: '369.61px',
-  },
-};
-
-const SKELETON_HEIGHT: SkeletonSize = {
-  title: '33.59px',
-  github: '6px',
-  email: '6px',
-  text01: '19.59px',
-  text02: '19.59px',
-};
-
-const CodeView = ({ data, isFetching, language }: Props) => (
-  <div className='flex flex-col justify-center gap-4 rounded-xl bg-white p-6 pt-14 shadow-md xl:h-[400px] dark:bg-slate-800'>
-    {isFetching ? (
-      <Skeleton
-        className={cn(`h-[${SKELETON_HEIGHT.title}] w-[${SKELETON_WIDTH[language].title}]`)}
-      />
-    ) : (
-      <h4 className='text-body-md-bold sm:text-heading-h5'>{data.code.title}</h4>
-    )}
-    <div className='space-y-4 sm:space-y-2'>
-      <div className='flex flex-col sm:flex-row sm:items-center sm:gap-2'>
-        {isFetching ? (
-          <Skeleton
-            className={cn(`h-[${SKELETON_HEIGHT.github}] w-[${SKELETON_WIDTH[language].github}]`)}
-          />
-        ) : (
-          <>
-            <FaGithub className='hidden sm:block' />
-            <span className='text-body-sm sm:text-body-md'>{data.code.github_text}</span>
-            <a
-              href={process.env.NEXT_PUBLIC_GITHUB_URL}
-              className='text-body-sm underline underline-offset-4 transition-colors hover:text-teal-500 sm:text-body-md'
-              target='_blank'
-              rel='noopener noreferrer'
-            >
-              Github
-            </a>
-          </>
-        )}
-      </div>
-      <div className='flex flex-col sm:flex-row sm:items-center sm:gap-2'>
-        {isFetching ? (
-          <Skeleton
-            className={cn(`h-[${SKELETON_HEIGHT.email}] w-[${SKELETON_WIDTH[language].email}]`)}
-          />
-        ) : (
-          <>
-            <FaEnvelope className='hidden sm:block' />
-            <span className='text-body-sm sm:text-body-md'>{data.code.email_text}</span>
-            <a
-              href='mailto:wkdaudwn1028@gmail.com'
-              className='text-body-sm underline underline-offset-4 transition-colors hover:text-teal-500 sm:text-body-md'
-            >
-              {data.code.email_button_text}
-            </a>
-          </>
-        )}
-      </div>
-    </div>
-    <div className='space-y-1'>
-      {isFetching ? (
-        <>
-          <Skeleton
-            className={cn(`h-[${SKELETON_HEIGHT.text01}] w-[${SKELETON_WIDTH[language].text01}]`)}
-          />
-          <Skeleton
-            className={cn(`h-[${SKELETON_HEIGHT.text02}] w-[${SKELETON_WIDTH[language].text02}]`)}
-          />
-        </>
-      ) : (
-        <>
-          <p className='text-body-sm text-gray-600 dark:text-gray-300'>{data.code.text01}</p>
-          <p className='text-body-sm text-gray-500 italic'>&quot;{data.code.text02}&quot;</p>
-        </>
+  return (
+    <div
+      className={cn(
+        'flex w-full flex-col justify-center gap-4 rounded-xl bg-white p-6 shadow-md xl:h-[400px] dark:bg-slate-800',
+        !isFetching && 'pt-14 sm:pt-6'
       )}
+    >
+      {isFetching ? (
+        <Skeleton
+          className={cn(`h-[${skeleton.title.height}] w-full`, `sm:w-[${skeleton.title.smWidth}]`)}
+        />
+      ) : (
+        <h4 className='text-body-md-bold sm:text-heading-h5'>{data.code.title}</h4>
+      )}
+
+      <div className='space-y-4 sm:space-y-2'>
+        <div className='flex flex-col sm:flex-row sm:items-center sm:gap-2'>
+          {isFetching ? (
+            <Skeleton
+              className={cn(
+                `h-[${skeleton.github.height}] w-full`,
+                `sm:w-[${skeleton.github.smWidth}]`
+              )}
+            />
+          ) : (
+            <>
+              <FaGithub className='hidden sm:block' />
+              <span className='text-body-sm sm:text-body-md'>{data.code.github_text}</span>
+              <a
+                href={process.env.NEXT_PUBLIC_GITHUB_URL}
+                className='text-body-sm underline underline-offset-4 transition-colors hover:text-teal-500 sm:text-body-md'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                Github
+              </a>
+            </>
+          )}
+        </div>
+
+        <div className='flex flex-col sm:flex-row sm:items-center sm:gap-2'>
+          {isFetching ? (
+            <Skeleton
+              className={cn(
+                `h-[${skeleton.email.height}] w-full`,
+                `sm:w-[${skeleton.email.smWidth}]`
+              )}
+            />
+          ) : (
+            <>
+              <FaEnvelope className='hidden sm:block' />
+              <span className='text-body-sm sm:text-body-md'>{data.code.email_text}</span>
+              <a
+                href='mailto:wkdaudwn1028@gmail.com'
+                className='text-body-sm underline underline-offset-4 transition-colors hover:text-teal-500 sm:text-body-md'
+              >
+                {data.code.email_button_text}
+              </a>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className='space-y-1'>
+        {isFetching ? (
+          <>
+            <Skeleton
+              className={cn(
+                `h-[${skeleton.text01.height}] w-2/3`,
+                `sm:w-[${skeleton.text01.smWidth}]`
+              )}
+            />
+            <Skeleton
+              className={cn(
+                `h-[${skeleton.text02.height}] w-1/2`,
+                `sm:w-[${skeleton.text02.smWidth}]`
+              )}
+            />
+          </>
+        ) : (
+          <>
+            <p className='text-body-sm text-gray-600 dark:text-gray-300'>{data.code.text01}</p>
+            <p className='text-body-sm text-gray-500 italic'>&quot;{data.code.text02}&quot;</p>
+          </>
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default CodeView;

--- a/src/app/(main)/_components/code-view.tsx
+++ b/src/app/(main)/_components/code-view.tsx
@@ -5,33 +5,60 @@ import { cn } from '@/lib/utils';
 import type { HelloResponse } from '@/types/hello';
 import type { Language } from '@/types/language';
 
-type SkeletonSize = {
-  height: string;
-  smWidth: string;
+type SkeletonItem = {
+  base: string;
+  smHeight: string;
+  smWidth: Record<Language, string>;
 };
 
 type SkeletonSizeMap = {
-  title: SkeletonSize;
-  github: SkeletonSize;
-  email: SkeletonSize;
-  text01: SkeletonSize;
-  text02: SkeletonSize;
+  title: SkeletonItem;
+  github: SkeletonItem;
+  email: SkeletonItem;
+  text01: SkeletonItem;
+  text02: SkeletonItem;
 };
 
-const SKELETON_SIZES: Record<Language, SkeletonSizeMap> = {
-  ko: {
-    title: { height: '34px', smWidth: '435px' },
-    github: { height: '24px', smWidth: '397px' },
-    email: { height: '24px', smWidth: '378px' },
-    text01: { height: '20px', smWidth: '397px' },
-    text02: { height: '20px', smWidth: '220px' },
+const SKELETON_SIZES: SkeletonSizeMap = {
+  title: {
+    base: 'h-[34px] w-full',
+    smHeight: 'sm:h-[34px]',
+    smWidth: {
+      ko: 'sm:w-[435px]',
+      en: 'sm:w-[460px]',
+    },
   },
-  en: {
-    title: { height: '34px', smWidth: '460px' },
-    github: { height: '24px', smWidth: '590px' },
-    email: { height: '24px', smWidth: '590px' },
-    text01: { height: '20px', smWidth: '530px' },
-    text02: { height: '20px', smWidth: '370px' },
+  github: {
+    base: 'h-[24px] w-full',
+    smHeight: 'sm:h-[24px]',
+    smWidth: {
+      ko: 'sm:w-[397px]',
+      en: 'sm:w-[590px]',
+    },
+  },
+  email: {
+    base: 'h-[24px] w-full',
+    smHeight: 'sm:h-[24px]',
+    smWidth: {
+      ko: 'sm:w-[378px]',
+      en: 'sm:w-[590px]',
+    },
+  },
+  text01: {
+    base: 'h-[20px] w-2/3',
+    smHeight: 'sm:h-[20px]',
+    smWidth: {
+      ko: 'sm:w-[397px]',
+      en: 'sm:w-[530px]',
+    },
+  },
+  text02: {
+    base: 'h-[20px] w-1/2',
+    smHeight: 'sm:h-[20px]',
+    smWidth: {
+      ko: 'sm:w-[220px]',
+      en: 'sm:w-[370px]',
+    },
   },
 };
 
@@ -42,18 +69,22 @@ type Props = {
 };
 
 const CodeView = ({ data, isFetching, language }: Props) => {
-  const skeleton = SKELETON_SIZES[language];
+  const skeleton = SKELETON_SIZES;
 
   return (
     <div
       className={cn(
         'flex w-full flex-col justify-center gap-4 rounded-xl bg-white p-6 shadow-md xl:h-[400px] dark:bg-slate-800',
-        !isFetching && 'pt-14 sm:pt-6'
+        !isFetching && 'pt-14'
       )}
     >
       {isFetching ? (
         <Skeleton
-          className={cn(`h-[${skeleton.title.height}] w-full`, `sm:w-[${skeleton.title.smWidth}]`)}
+          className={cn(
+            skeleton.title.base,
+            skeleton.title.smHeight,
+            skeleton.title.smWidth[language]
+          )}
         />
       ) : (
         <h4 className='text-body-md-bold sm:text-heading-h5'>{data.code.title}</h4>
@@ -64,8 +95,9 @@ const CodeView = ({ data, isFetching, language }: Props) => {
           {isFetching ? (
             <Skeleton
               className={cn(
-                `h-[${skeleton.github.height}] w-full`,
-                `sm:w-[${skeleton.github.smWidth}]`
+                skeleton.github.base,
+                skeleton.github.smHeight,
+                skeleton.github.smWidth[language]
               )}
             />
           ) : (
@@ -88,8 +120,9 @@ const CodeView = ({ data, isFetching, language }: Props) => {
           {isFetching ? (
             <Skeleton
               className={cn(
-                `h-[${skeleton.email.height}] w-full`,
-                `sm:w-[${skeleton.email.smWidth}]`
+                skeleton.email.base,
+                skeleton.email.smHeight,
+                skeleton.email.smWidth[language]
               )}
             />
           ) : (
@@ -112,14 +145,16 @@ const CodeView = ({ data, isFetching, language }: Props) => {
           <>
             <Skeleton
               className={cn(
-                `h-[${skeleton.text01.height}] w-2/3`,
-                `sm:w-[${skeleton.text01.smWidth}]`
+                skeleton.text01.base,
+                skeleton.text01.smHeight,
+                skeleton.text01.smWidth[language]
               )}
             />
             <Skeleton
               className={cn(
-                `h-[${skeleton.text02.height}] w-1/2`,
-                `sm:w-[${skeleton.text02.smWidth}]`
+                skeleton.text02.base,
+                skeleton.text02.smHeight,
+                skeleton.text02.smWidth[language]
               )}
             />
           </>

--- a/src/app/(main)/_components/code-view.tsx
+++ b/src/app/(main)/_components/code-view.tsx
@@ -3,24 +3,62 @@ import { FaGithub, FaEnvelope } from 'react-icons/fa';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import type { HelloResponse } from '@/types/hello';
+import type { Language } from '@/types/language';
 
 type Props = {
   data: HelloResponse;
   isFetching: boolean;
-  language: string;
+  language: Language;
+};
+
+type SkeletonSize = {
+  title: string;
+  github: string;
+  email: string;
+  text01: string;
+  text02: string;
+};
+
+const SKELETON_WIDTH: Record<Language, SkeletonSize> = {
+  ko: {
+    title: '460.8px',
+    github: '589.61px',
+    email: '589.61px',
+    text01: '529.2px',
+    text02: '369.61px',
+  },
+  en: {
+    title: '460.8px',
+    github: '589.61px',
+    email: '589.61px',
+    text01: '529.2px',
+    text02: '369.61px',
+  },
+};
+
+const SKELETON_HEIGHT: SkeletonSize = {
+  title: '33.59px',
+  github: '6px',
+  email: '6px',
+  text01: '19.59px',
+  text02: '19.59px',
 };
 
 const CodeView = ({ data, isFetching, language }: Props) => (
   <div className='flex flex-col justify-center gap-4 rounded-xl bg-white p-6 pt-14 shadow-md xl:h-[400px] dark:bg-slate-800'>
     {isFetching ? (
-      <Skeleton className={cn('h-[33.59px] w-[434.64px]', language === 'en' && 'w-[460.8px]')} />
+      <Skeleton
+        className={cn(`h-[${SKELETON_HEIGHT.title}] w-[${SKELETON_WIDTH[language].title}]`)}
+      />
     ) : (
       <h4 className='text-body-md-bold sm:text-heading-h5'>{data.code.title}</h4>
     )}
     <div className='space-y-4 sm:space-y-2'>
       <div className='flex flex-col sm:flex-row sm:items-center sm:gap-2'>
         {isFetching ? (
-          <Skeleton className={cn('h-6 w-[397.11px]', language === 'en' && 'w-[589.61px]')} />
+          <Skeleton
+            className={cn(`h-[${SKELETON_HEIGHT.github}] w-[${SKELETON_WIDTH[language].github}]`)}
+          />
         ) : (
           <>
             <FaGithub className='hidden sm:block' />
@@ -38,7 +76,9 @@ const CodeView = ({ data, isFetching, language }: Props) => (
       </div>
       <div className='flex flex-col sm:flex-row sm:items-center sm:gap-2'>
         {isFetching ? (
-          <Skeleton className={cn('h-6 w-[377.92px]', language === 'en' && 'w-[589.61px]')} />
+          <Skeleton
+            className={cn(`h-[${SKELETON_HEIGHT.email}] w-[${SKELETON_WIDTH[language].email}]`)}
+          />
         ) : (
           <>
             <FaEnvelope className='hidden sm:block' />
@@ -57,10 +97,10 @@ const CodeView = ({ data, isFetching, language }: Props) => (
       {isFetching ? (
         <>
           <Skeleton
-            className={cn('h-[19.59px] w-[397.11px]', language === 'en' && 'w-[529.2px]')}
+            className={cn(`h-[${SKELETON_HEIGHT.text01}] w-[${SKELETON_WIDTH[language].text01}]`)}
           />
           <Skeleton
-            className={cn('h-[19.59px] w-[219.95px]', language === 'en' && 'w-[369.61px]')}
+            className={cn(`h-[${SKELETON_HEIGHT.text02}] w-[${SKELETON_WIDTH[language].text02}]`)}
           />
         </>
       ) : (

--- a/src/app/(main)/_components/code-view.tsx
+++ b/src/app/(main)/_components/code-view.tsx
@@ -1,41 +1,74 @@
 import { FaGithub, FaEnvelope } from 'react-icons/fa';
 
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
 import type { HelloResponse } from '@/types/hello';
 
 type Props = {
   data: HelloResponse;
+  isFetching: boolean;
+  language: string;
 };
 
-const CodeView = ({ data }: Props) => (
+const CodeView = ({ data, isFetching, language }: Props) => (
   <div className='flex flex-col justify-center gap-4 rounded-xl bg-white p-6 pt-14 shadow-md xl:h-[400px] dark:bg-slate-800'>
-    <h4 className='text-body-md-bold sm:text-heading-h5'>{data.code.title}!</h4>
+    {isFetching ? (
+      <Skeleton className={cn('h-[33.59px] w-[434.64px]', language === 'en' && 'w-[460.8px]')} />
+    ) : (
+      <h4 className='text-body-md-bold sm:text-heading-h5'>{data.code.title}</h4>
+    )}
     <div className='space-y-4 sm:space-y-2'>
       <div className='flex flex-col sm:flex-row sm:items-center sm:gap-2'>
-        <FaGithub className='hidden sm:block' />
-        <span className='text-body-sm sm:text-body-md'>{data.code.github_text} 👉</span>
-        <a
-          href={process.env.NEXT_PUBLIC_GITHUB_URL}
-          className='text-body-sm underline underline-offset-4 transition-colors hover:text-teal-500 sm:text-body-md'
-          target='_blank'
-          rel='noopener noreferrer'
-        >
-          Github
-        </a>
+        {isFetching ? (
+          <Skeleton className={cn('h-6 w-[397.11px]', language === 'en' && 'w-[589.61px]')} />
+        ) : (
+          <>
+            <FaGithub className='hidden sm:block' />
+            <span className='text-body-sm sm:text-body-md'>{data.code.github_text}</span>
+            <a
+              href={process.env.NEXT_PUBLIC_GITHUB_URL}
+              className='text-body-sm underline underline-offset-4 transition-colors hover:text-teal-500 sm:text-body-md'
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              Github
+            </a>
+          </>
+        )}
       </div>
       <div className='flex flex-col sm:flex-row sm:items-center sm:gap-2'>
-        <FaEnvelope className='hidden sm:block' />
-        <span className='text-body-sm sm:text-body-md'>{data.code.email_text} 📨</span>
-        <a
-          href='mailto:wkdaudwn1028@gmail.com'
-          className='text-body-sm underline underline-offset-4 transition-colors hover:text-teal-500 sm:text-body-md'
-        >
-          {data.code.email_button_text}
-        </a>
+        {isFetching ? (
+          <Skeleton className={cn('h-6 w-[377.92px]', language === 'en' && 'w-[589.61px]')} />
+        ) : (
+          <>
+            <FaEnvelope className='hidden sm:block' />
+            <span className='text-body-sm sm:text-body-md'>{data.code.email_text}</span>
+            <a
+              href='mailto:wkdaudwn1028@gmail.com'
+              className='text-body-sm underline underline-offset-4 transition-colors hover:text-teal-500 sm:text-body-md'
+            >
+              {data.code.email_button_text}
+            </a>
+          </>
+        )}
       </div>
     </div>
     <div className='space-y-1'>
-      <p className='text-body-sm text-gray-600 dark:text-gray-300'>{data.code.text01}</p>
-      <p className='text-body-sm text-gray-500 italic'>&quot;{data.code.text02}&quot;</p>
+      {isFetching ? (
+        <>
+          <Skeleton
+            className={cn('h-[19.59px] w-[397.11px]', language === 'en' && 'w-[529.2px]')}
+          />
+          <Skeleton
+            className={cn('h-[19.59px] w-[219.95px]', language === 'en' && 'w-[369.61px]')}
+          />
+        </>
+      ) : (
+        <>
+          <p className='text-body-sm text-gray-600 dark:text-gray-300'>{data.code.text01}</p>
+          <p className='text-body-sm text-gray-500 italic'>&quot;{data.code.text02}&quot;</p>
+        </>
+      )}
     </div>
   </div>
 );

--- a/src/app/(main)/_components/main.tsx
+++ b/src/app/(main)/_components/main.tsx
@@ -10,6 +10,8 @@ import ErrorContent from '@/components/shared/error-content';
 import FadeInUp from '@/components/shared/fade-in-up';
 import Typewriter from '@/components/shared/typewriter';
 import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import Spinner from '@/components/ui/spinner';
 import { Toggle } from '@/components/ui/toggle';
 import { fetchHello } from '@/lib/api/hello';
 import { cn } from '@/lib/utils';
@@ -44,7 +46,7 @@ import { FaGithub, FaEnvelope } from 'react-icons/fa';
 
 const Hello = () => (
   <div className='flex h-[400px] flex-col justify-center gap-4 rounded-xl bg-white p-6 pt-14 shadow-md dark:bg-slate-800'>
-    <h4 className='text-heading-h6 sm:text-heading-h5'>${data.code.title}!</h4>
+    <h4 className='text-heading-h6 sm:text-heading-h5'>${data.code.title}</h4>
     <div className='space-y-4 sm:space-y-2'>
       <div className='flex flex-col sm:flex-row sm:items-center sm:gap-2'>
         <FaGithub className='hidden sm:block' />
@@ -98,10 +100,6 @@ export default Hello;
     [data]
   );
 
-  if (isFetching) {
-    return <div>Loading...</div>;
-  }
-
   if (isError) {
     return <ErrorContent />;
   }
@@ -110,32 +108,47 @@ export default Hello;
     <div className='flex h-full flex-col items-center justify-center gap-5 px-4 py-10 xl:gap-8'>
       <div className='h-[110px] sm:h-[139px]'>
         <FadeInUp>
-          <Typewriter lines={lines} isLoop />
+          {isFetching ? (
+            <div className='flex flex-col gap-2'>
+              <Skeleton className='h-[27px] w-[130px]' />
+              <Skeleton className='h-[66px] w-[383.41px]' />
+              <Skeleton className='h-[41px] w-[261.61px]' />
+            </div>
+          ) : (
+            <Typewriter lines={lines} isLoop />
+          )}
         </FadeInUp>
       </div>
       <div className='flex w-full items-center justify-center gap-5 xl:flex-row'>
         <div className={cn('lg:w-fit', isShowCodeHighlight && 'w-full')}>
           <FadeInUp>
             <div className='relative'>
-              <Toggle
-                aria-label='Toggle italic'
-                className='absolute top-2 right-2 z-10'
-                pressed={isShowCodeHighlight}
-                onPressedChange={() => setIsShowCodeHighlight(prev => !prev)}
-              >
-                <MdCode />
-                <Label className='cursor-pointer'>code</Label>
-              </Toggle>
+              {!isFetching && (
+                <Toggle
+                  aria-label='Toggle italic'
+                  className='absolute top-2 right-2 z-10'
+                  pressed={isShowCodeHighlight}
+                  onPressedChange={() => setIsShowCodeHighlight(prev => !prev)}
+                >
+                  <MdCode />
+                  <Label className='cursor-pointer'>code</Label>
+                </Toggle>
+              )}
               {isShowCodeHighlight ? (
                 <CodeHighlight rawCode={rawCode} loadingClassName='w-full sm:w-[548px]' />
               ) : (
-                <CodeView data={data} />
+                <CodeView data={data} isFetching={isFetching} language={language} />
               )}
             </div>
           </FadeInUp>
         </div>
-        <div className='hidden items-center justify-center xl:flex'>
+        <div className='relative hidden items-center justify-center xl:flex'>
           <FadeInUp>
+            {isFetching && (
+              <div className='absolute z-10 flex h-full w-full items-center justify-center rounded-xl bg-black/50'>
+                <Spinner size='md' />
+              </div>
+            )}
             <SnakeGame />
           </FadeInUp>
         </div>

--- a/src/app/(main)/_components/main.tsx
+++ b/src/app/(main)/_components/main.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdCode } from 'react-icons/md';
 
@@ -25,10 +25,32 @@ type Props = {
   initialData: HelloResponse;
 };
 
-const SKELETON_SIZES = {
-  line1: { height: '27px', width: '130px' },
-  line2: { height: '66px', width: '383.41px' },
-  line3: { height: '41px', width: '261.61px' },
+type SkeletonSize = {
+  line1: { base: string; sm?: string };
+  line2: { base: string; smHeight: string; smWidth: Record<Language, string> };
+  line3: { base: string; smHeight: string; smWidth: Record<Language, string> };
+};
+
+const SKELETON_SIZES: SkeletonSize = {
+  line1: {
+    base: 'h-[24px] w-[130px] sm:h-[27px]',
+  },
+  line2: {
+    base: 'h-[46.8px] w-full',
+    smHeight: 'sm:h-[66px]',
+    smWidth: {
+      ko: 'sm:w-[383.41px]',
+      en: 'sm:w-[542px]',
+    },
+  },
+  line3: {
+    base: 'h-[33.59px] w-[261.61px]',
+    smHeight: 'sm:h-[41px]',
+    smWidth: {
+      ko: 'sm:w-[261.61px]',
+      en: 'sm:w-[380px]',
+    },
+  },
 };
 
 const Main = ({ initialData }: Props) => {
@@ -107,24 +129,39 @@ export default Hello;
     [data]
   );
 
+  useEffect(() => {
+    setIsShowCodeHighlight(false);
+  }, [language]);
+
   if (isError) {
     return <ErrorContent />;
   }
 
   return (
-    <div className='flex h-full flex-col items-center justify-center gap-5 px-4 py-10 xl:gap-8'>
-      <div className='h-[110px] sm:h-[139px]'>
+    <div
+      className={cn(
+        'flex h-full flex-col items-center justify-center gap-5 px-4 py-10 xl:gap-8',
+        isFetching && 'gap-8'
+      )}
+    >
+      <div className='h-[110px] w-full sm:h-[139px] sm:w-auto'>
         <FadeInUp>
           {isFetching ? (
             <div className='flex flex-col gap-2'>
+              <Skeleton className={SKELETON_SIZES.line1.base} />
               <Skeleton
-                className={`h-[${SKELETON_SIZES.line1.height}] w-[${SKELETON_SIZES.line1.width}]`}
+                className={cn(
+                  SKELETON_SIZES.line2.base,
+                  SKELETON_SIZES.line2.smHeight,
+                  SKELETON_SIZES.line2.smWidth[language as Language]
+                )}
               />
               <Skeleton
-                className={`h-[${SKELETON_SIZES.line2.height}] w-[${SKELETON_SIZES.line2.width}]`}
-              />
-              <Skeleton
-                className={`h-[${SKELETON_SIZES.line3.height}] w-[${SKELETON_SIZES.line3.width}]`}
+                className={cn(
+                  SKELETON_SIZES.line3.base,
+                  SKELETON_SIZES.line3.smHeight,
+                  SKELETON_SIZES.line3.smWidth[language as Language]
+                )}
               />
             </div>
           ) : (
@@ -133,9 +170,9 @@ export default Hello;
         </FadeInUp>
       </div>
       <div className='flex w-full items-center justify-center gap-5 xl:flex-row'>
-        <div className={cn('lg:w-fit', isShowCodeHighlight && 'w-full')}>
+        <div className={cn('w-full lg:w-fit', isShowCodeHighlight && 'w-full')}>
           <FadeInUp>
-            <div className='relative'>
+            <div className='relative w-full'>
               {!isFetching && (
                 <Toggle
                   aria-label='Toggle italic'

--- a/src/app/(main)/_components/main.tsx
+++ b/src/app/(main)/_components/main.tsx
@@ -170,7 +170,7 @@ export default Hello;
         </FadeInUp>
       </div>
       <div className='flex w-full items-center justify-center gap-5 xl:flex-row'>
-        <div className={cn('w-full lg:w-fit', isShowCodeHighlight && 'w-full')}>
+        <div className={cn('w-full lg:w-fit')}>
           <FadeInUp>
             <div className='relative w-full'>
               {!isFetching && (

--- a/src/app/(main)/_components/main.tsx
+++ b/src/app/(main)/_components/main.tsx
@@ -16,12 +16,19 @@ import { Toggle } from '@/components/ui/toggle';
 import { fetchHello } from '@/lib/api/hello';
 import { cn } from '@/lib/utils';
 import type { HelloResponse } from '@/types/hello';
+import type { Language } from '@/types/language';
 
 import CodeView from './code-view';
 import SnakeGame from './snake-game';
 
 type Props = {
   initialData: HelloResponse;
+};
+
+const SKELETON_SIZES = {
+  line1: { height: '27px', width: '130px' },
+  line2: { height: '66px', width: '383.41px' },
+  line3: { height: '41px', width: '261.61px' },
 };
 
 const Main = ({ initialData }: Props) => {
@@ -110,9 +117,15 @@ export default Hello;
         <FadeInUp>
           {isFetching ? (
             <div className='flex flex-col gap-2'>
-              <Skeleton className='h-[27px] w-[130px]' />
-              <Skeleton className='h-[66px] w-[383.41px]' />
-              <Skeleton className='h-[41px] w-[261.61px]' />
+              <Skeleton
+                className={`h-[${SKELETON_SIZES.line1.height}] w-[${SKELETON_SIZES.line1.width}]`}
+              />
+              <Skeleton
+                className={`h-[${SKELETON_SIZES.line2.height}] w-[${SKELETON_SIZES.line2.width}]`}
+              />
+              <Skeleton
+                className={`h-[${SKELETON_SIZES.line3.height}] w-[${SKELETON_SIZES.line3.width}]`}
+              />
             </div>
           ) : (
             <Typewriter lines={lines} isLoop />
@@ -137,7 +150,7 @@ export default Hello;
               {isShowCodeHighlight ? (
                 <CodeHighlight rawCode={rawCode} loadingClassName='w-full sm:w-[548px]' />
               ) : (
-                <CodeView data={data} isFetching={isFetching} language={language} />
+                <CodeView data={data} isFetching={isFetching} language={language as Language} />
               )}
             </div>
           </FadeInUp>

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
 
+import Spinner from '@/components/ui/spinner';
 import { shared, page } from '@/constants/metadata';
 import { fetchHello } from '@/lib/api/hello';
 import { getLangFromCookie } from '@/lib/get-lang-from-cookie';
@@ -31,7 +32,13 @@ const MainPage = async () => {
   const helloData = await fetchHello({ lang });
 
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense
+      fallback={
+        <div className='flex h-full flex-col items-center justify-center gap-5 px-4 py-10 xl:gap-8'>
+          <Spinner size='md' />
+        </div>
+      }
+    >
       <Main initialData={helloData} />
     </Suspense>
   );

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import type { ComponentProps } from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Skeleton = ({ className, ...props }: ComponentProps<'div'>) => (
+  <div
+    data-slot='skeleton'
+    className={cn('animate-pulse rounded-sm bg-gray-300 dark:bg-gray-800', className)}
+    {...props}
+  />
+);
+
+export { Skeleton };

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,5 +1,4 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import { PropsWithChildren } from 'react';
 
 import { cn } from '@/lib/utils';
 

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,0 +1,1 @@
+export type Language = 'ko' | 'en';


### PR DESCRIPTION
## 🔍 Overview

<!-- Briefly describe what this PR does -->
- `shadcn/ui` 사용하여 `Skeleton` 컴포넌트 설치
- 메인페이지에서 API 호출시 로딩 기간동안 Skeleton UI로 보여지는 작업 추가
- 메인페이지 Suspense fallback은 Spinner 아이콘으로 표시되도록 작업
- 다른 거 로딩중일 때 Snake game만 로딩이 안되는 게 부자연스러워서, Spinner Dimmer 처리 추가
- 언어별로 길이(width)가 다르기 때문에 `cn` 사용하여 언어별 너비 세부 조절

## ✅ What’s Included

<!-- Please check the relevant items below -->

- [x] Feature
- [ ] Bug Fix
- [ ] UI Enhancement
- [ ] Performance Improvement
- [ ] Code Refactor
- [ ] Test Code
- [ ] Others (describe below)

## 📸 Screenshots

<!-- Add screenshots if the PR includes UI work -->
- 최소 렌더시 보여주는 Suspense fallback 화면 (Spinner 사용)
![image](https://github.com/user-attachments/assets/2b0bb144-fda0-44fd-ba5f-163075c2112b)

- 언어(ko, en) 변경하여 API 재호출시 보여주는 Skeleton UI
![image](https://github.com/user-attachments/assets/ff08da58-83cc-4c0c-94f8-ae9a8b06c6e0)

- 모바일 Skeleton UI
![image](https://github.com/user-attachments/assets/e1284079-0c59-4f8b-86df-7360dccd82c1)

## 🔗 Related Issues

<!-- Add related issue numbers if applicable -->

- Closes #

## 💬 Additional Notes

<!-- Any extra context, TODOs, or implementation details -->
