### PR TITLE
fix: 메인 페이지에서 최초 렌더시 API 중복 호출하는 버그 수정

### DIFF
--- a/src/app/(main)/_components/main.tsx
+++ b/src/app/(main)/_components/main.tsx
@@ -64,6 +64,7 @@ const Main = ({ initialData }: Props) => {
     queryKey: ['hello', language],
     queryFn: () => fetchHello({ lang: language }),
     initialData,
+    enabled: language !== initialData.lang,
     refetchOnMount: process.env.NODE_ENV === 'development',
     refetchOnWindowFocus: false,
     refetchOnReconnect: true,


### PR DESCRIPTION
## 🔍 Overview

<!-- Briefly describe what this PR does -->
- 메인(hello) 페이지 최초 렌더시에 API를 두 번 호출하는 버그 수정
  - Server Side에서 1회, Client Side에서 1회. 총 2회 호출
  - Client Side에서 language 변화 감지를 해서 변화를 했을 경우에만 API를 호출하도록 enabled 옵션 추가

## ✅ What’s Included

<!-- Please check the relevant items below -->

- [ ] Feature
- [x] Bug Fix
- [ ] UI Enhancement
- [ ] Performance Improvement
- [ ] Code Refactor
- [ ] Test Code
- [ ] Others (describe below)

## 📸 Screenshots

<!-- Add screenshots if the PR includes UI work -->

## 🔗 Related Issues

<!-- Add related issue numbers if applicable -->

- Closes #

## 💬 Additional Notes

<!-- Any extra context, TODOs, or implementation details -->
- 페이지 진입 후 최초 렌더시엔 Servier Side에서 API 호출
- 이후에 language가 변하면 Client Side에서 API 호출